### PR TITLE
Vendoring doesn't work if we use ShopRunner as dep

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/ShopRunner/terraform-provider-snowflake/snowflake"
+	"github.com/sagansystems/terraform-provider-snowflake/snowflake"
 	"github.com/hashicorp/terraform/plugin"
 )
 


### PR DESCRIPTION
Changing the dependency in for from `ShopRunner/terraform-provider-snowflake` to `sagansystems/terraform-provider-snowflake` since with the former, go tries to find deps in `ShopRunner/terrafrom-provider-snowflake/vendor`