### PR TITLE
Add ability to manage role grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,17 @@ resource "snowflake_user" "tf_test_user" {
 | `user` | The username of the user | String | TRUE |
 | `plaintext_password` | Password of the user. Ensure that passwords conform to the complexity requirements by Snowflake | String | TRUE |
 | `default_role` | Default role the user assumes. Defaults to `null` | String | FALSE |
+
+### Snowflake Role Grant Management
+```
+resource "snowflake_role_grant" "tf_test_role_grant" {
+  role = "ACCOUNTADMIN"
+  user = "tf_test_user"
+}
+```
+
+##### Properties
+| Property | Description | Type | Required |
+| ------ | ------ | ------ | ------ |
+| `role` | The role to grant | String | TRUE |
+| `user` | The user to which to grant the role| String | TRUE |

--- a/snowflake/provider.go
+++ b/snowflake/provider.go
@@ -65,9 +65,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"snowflake_warehouse": resourceWarehouse(),
-			"snowflake_database":  resourceDatabase(),
-			"snowflake_user":      resourceUser(),
+			"snowflake_warehouse":  resourceWarehouse(),
+			"snowflake_database":   resourceDatabase(),
+			"snowflake_user":       resourceUser(),
+			"snowflake_role_grant": resourceRoleGrant(),
 			//"snowflake_grant":     resourceGrant(),
 		},
 

--- a/snowflake/resource_role_grant.go
+++ b/snowflake/resource_role_grant.go
@@ -1,0 +1,113 @@
+package snowflake
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRoleGrant() *schema.Resource {
+	return &schema.Resource{
+		Create: createRoleGrant,
+		Read:   readRoleGrant,
+		Delete: deleteRoleGrant,
+
+		Schema: map[string]*schema.Schema{
+			"role": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the role to grant",
+				ForceNew:    true,
+			},
+
+			"user": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The user to which this role should be granted",
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func createRoleGrant(d *schema.ResourceData, meta interface{}) error {
+	db := meta.(*providerConfiguration).DB
+
+	role := d.Get("role").(string)
+	user := d.Get("user").(string)
+
+	d.SetId(roleGrantIDFromParams(role, user))
+
+	stmtSQL := fmt.Sprintf("GRANT ROLE \"%s\" TO USER \"%s\"", role, user)
+
+	log.Println("Executing statement:", stmtSQL)
+
+	if _, err := db.Exec(stmtSQL); err != nil {
+		return err
+	}
+
+	return readRoleGrant(d, meta)
+}
+
+func readRoleGrant(d *schema.ResourceData, meta interface{}) error {
+	db := meta.(*providerConfiguration).DB
+
+	role, user := paramsFromRoleGrantID(d.Id())
+
+	stmtSQL := fmt.Sprintf("SHOW GRANTS TO USER \"%s\"", user)
+
+	log.Println("Executing statement:", stmtSQL)
+
+	rows, err := db.Query(stmtSQL)
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var dbCreatedAt string
+		var dbRole string
+		var dbGrantedTo string
+		var dbGranteeName string
+		var dbGrantedBy string
+		if err := rows.Scan(&dbCreatedAt, &dbRole, &dbGrantedTo, &dbGranteeName, &dbGrantedBy); err != nil {
+			return err
+		}
+		if role == dbRole {
+			d.Set("role", dbRole)
+			d.Set("user", dbGranteeName)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("The grant of role %s to user %s does not exist.", role, user)
+}
+
+func deleteRoleGrant(d *schema.ResourceData, meta interface{}) error {
+	db := meta.(*providerConfiguration).DB
+
+	role, user := paramsFromRoleGrantID(d.Id())
+
+	stmtSQL := fmt.Sprintf("REVOKE ROLE \"%s\" FROM USER \"%s\"", role, user)
+
+	log.Println("Executing statement:", stmtSQL)
+
+	_, err := db.Exec(stmtSQL)
+	if err == nil {
+		d.SetId("")
+	}
+
+	return err
+}
+
+func paramsFromRoleGrantID(id string) (role, user string) {
+	splits := strings.Split(id, "-")
+	return splits[0], splits[1]
+}
+
+func roleGrantIDFromParams(role, user string) string {
+	return fmt.Sprintf("%s-%s", role, user)
+}

--- a/snowflake/resource_role_grant_test.go
+++ b/snowflake/resource_role_grant_test.go
@@ -1,0 +1,31 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestRoleGrantSnowflakeDatabase(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testSnowflakeProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testSnowflakeRoleGrantConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"snowflake_role_grant", "name", "test"),
+					resource.TestCheckResourceAttr("snowflake_role_grant", "role", "tf-test"),
+					resource.TestCheckResourceAttr("snowflake_role_grant", "user", "tf-test-user"),
+				),
+			},
+		},
+	})
+}
+
+var testSnowflakeRoleGrantConfig = `
+resource "snowflake_role_grant" "test" {
+  role = "tf-test-role"
+  user = "tf-test-user"
+}
+`


### PR DESCRIPTION
**What**
- This only allows granting of roles to users, not roles to roles
- No updates, making changes requires creating a new resource

**Why**
Limiting the functionality this way as allowing both complicates the code unnecessarily and requires handling different returns from the show queries. Granting roles to roles may belong in the grants resource.

A role grant cannot really be updated. If either the name of the role or the name of the user changes, that requires revoking the old role from the old user and granting new role to new user, a.k.a. a brand new grant.

**Plans**
Create
```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + snowflake_role_grant.tester
      id:   <computed>
      role: "TESTER"
      user: "LLEMPART"


Plan: 1 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```

Update
```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

-/+ snowflake_role_grant.tester (new resource required)
      id:   "TESTER-LLEMPART" => <computed> (forces new resource)
      role: "TESTER" => "OTHERTESTER" (forces new resource)
      user: "LLEMPART" => "LLEMPART"


Plan: 1 to add, 0 to change, 1 to destroy.

------------------------------------------------------------------------
```

Delete
```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  - snowflake_role_grant.tester


Plan: 0 to add, 0 to change, 1 to destroy.

------------------------------------------------------------------------
```