### PR TITLE
Read source resources correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ default: build
 build: fmtcheck
 	GO111MODULE=on go install
 
+# this only works on OS X
+install-local: build
+	@mkdir -p .terraform/plugins/darwin_amd64
+	@cp $(GOPATH)/bin/terraform-provider-snowflake .terraform/plugins/darwin_amd64/terraform-provider-snowflake_v0.1.0
+	@terraform init
+
 dev-image:
 	# don't remove the @ unless you want the GITHUB_TOKEN printed to the terminal
 	@docker build . \

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,12 @@
 resource "snowflake_warehouse" "warehouse_terraform" {
-      name              =   "dev_wh"
-      warehouse_size    =   "SMALL"
-      auto_resume       =   false
-      auto_suspend      =   600
-      comment           =   "terraform development warehouse"
+  name           = "DEV_WH"
+  warehouse_size = "SMALL"
+  auto_resume    = false
+  auto_suspend   = 600
+  comment        = "terraform development warehouse"
 }
 
 resource "snowflake_database" "database_terraform" {
-      name              =   "dev_db"
-      comment           =   "terraform development database"
+  name    = "DEV_DB"
+  comment = "terraform development database"
 }

--- a/snowflake/resource_role_grant.go
+++ b/snowflake/resource_role_grant.go
@@ -21,7 +21,6 @@ func resourceRoleGrant() *schema.Resource {
 				Description: "Name of the role to grant",
 				ForceNew:    true,
 			},
-
 			"user": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,

--- a/snowflake/resource_schema.go
+++ b/snowflake/resource_schema.go
@@ -85,7 +85,9 @@ func readSchema(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return fmt.Errorf("the schema %s.%s does not exist.", database, schema)
+	// the terraform thing to do if the resource does not exist is set id to the empty string
+	d.SetId("")
+	return nil
 }
 
 func deleteSchema(d *schema.ResourceData, meta interface{}) error {

--- a/snowflake/resource_warehouse.go
+++ b/snowflake/resource_warehouse.go
@@ -12,11 +12,8 @@ import (
 )
 
 const (
-	whNameAttr                            = "name"
-	whMaxConcurrencyLevelAttr             = "max_concurrency_level"
-	whStatementQueuedTimeOutInSecondsAttr = "statement_queued_timeout_in_seconds"
-	whStatementTimeoutInSecondsAttr       = "statement_timeout_in_seconds"
-	whCommentAttr                         = "comment"
+	whNameAttr    = "name"
+	whCommentAttr = "comment"
 
 	//Properties
 	whSizeAttr           = "warehouse_size"
@@ -36,31 +33,11 @@ func resourceWarehouse() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			whNameAttr: {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    false,
-				Description: "Identifier for the Snowflake warehouse;must be unique for your account ",
-			},
-			whMaxConcurrencyLevelAttr: {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     1,
-				ForceNew:    false,
-				Description: "Specifies the maximum number of SQL statements (queries, DDL, DML, etc.) a warehouse cluster can execute concurrently.  ",
-			},
-			whStatementQueuedTimeOutInSecondsAttr: {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     120,
-				ForceNew:    false,
-				Description: "Specifies the time, in seconds, a SQL statement (query, DDL, DML, etc.) can be queued on a warehouse before it is canceled by the system.",
-			},
-			whStatementTimeoutInSecondsAttr: {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     1000,
-				ForceNew:    false,
-				Description: "Specifies the time, in seconds, after which a running SQL statement (query, DDL, DML, etc.) is canceled by the system.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         false,
+				Description:      "Identifier for the Snowflake warehouse;must be unique for your account ",
+				DiffSuppressFunc: ignoreCase,
 			},
 			whCommentAttr: {
 				Type:        schema.TypeString,
@@ -70,11 +47,12 @@ func resourceWarehouse() *schema.Resource {
 				Description: "Specifies a comment for the warehouse.",
 			},
 			whSizeAttr: {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "XSMALL",
-				ForceNew:    false,
-				Description: "Specifies the size of virtual warehouse to create.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "XSMALL",
+				ForceNew:         false,
+				Description:      "Specifies the size of virtual warehouse to create.",
+				DiffSuppressFunc: ignoreCase,
 			},
 			whMaxClusterCount: {
 				Type:        schema.TypeInt,
@@ -167,9 +145,13 @@ func readWarehouse(d *schema.ResourceData, meta interface{}) error {
 
 	fmt.Printf(" Read Warehouse Executing query: %s \n", stmtSQL)
 	log.Println("Executing query:", stmtSQL)
-	var name, state, instanceType, size, minClusterCount, maxClusterCount, startedClusters, running, queued sql.NullString
-	var isDefault, isCurrent, autoSuspend, autoResume, available, provisioning, quiescing, other sql.NullString
-	var createdOn, resumedOn, updatedOn, owner, comment, resourceMonitor sql.NullString
+
+	var name, size, comment string
+	var minClusterCount, maxClusterCount int
+	var autoResume bool
+	var state, instanceType, startedClusters, running, queued sql.NullString
+	var isDefault, isCurrent, autoSuspend, available, provisioning, quiescing, other sql.NullString
+	var createdOn, resumedOn, updatedOn, owner, resourceMonitor sql.NullString
 	var actives, pendings, failed, suspended, uuid, scalingPolicy sql.NullString
 
 	err := db.QueryRow(stmtSQL).Scan(
@@ -182,35 +164,14 @@ func readWarehouse(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error during show create warehouse: %s", err)
 	}
 
+	//Properties
 	d.Set(whNameAttr, name)
-	d.Set("state", state)
-	d.Set("instance", instanceType)
 	d.Set(whSizeAttr, size)
-	d.Set("min_cluster_count", minClusterCount)
-	d.Set("max_cluster_count", maxClusterCount)
-	d.Set("started_clusters", startedClusters)
-	d.Set("running", running)
-	d.Set("queued", queued)
-	d.Set("is_default", isDefault)
-	d.Set("is_current", isCurrent)
-	d.Set("auto_suspend", autoSuspend)
-	d.Set("auto_resume", autoResume)
-	d.Set("available", available)
-	d.Set("provisioning", provisioning)
-	d.Set("quiescing", quiescing)
-	d.Set("other", other)
-	d.Set("create_on", createdOn)
-	d.Set("resumed_on", resumedOn)
-	d.Set("updated_on", updatedOn)
-	d.Set("owner", owner)
-	d.Set("comment", comment)
-	d.Set("resource_monitor", resourceMonitor)
-	d.Set("actives", actives)
-	d.Set("pendings", pendings)
-	d.Set("failed", failed)
-	d.Set("suspended", suspended)
-	d.Set("id", uuid)
-	d.Set("scaling_policy", scalingPolicy)
+	d.Set(whMinClusterCount, minClusterCount)
+	d.Set(whMaxClusterCount, maxClusterCount)
+	d.Set(whAutoSuspend, autoSuspend)
+	d.Set(whAutoResume, autoResume)
+	d.Set(whCommentAttr, comment)
 	return nil
 }
 

--- a/snowflake/utils.go
+++ b/snowflake/utils.go
@@ -12,6 +12,13 @@ func hashSum(contents interface{}) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(contents.(string))))
 }
 
+func ignoreCase(k, old, new string, d *schema.ResourceData) bool {
+	if strings.ToLower(old) == strings.ToLower(new) {
+		return true
+	}
+	return false
+}
+
 func privilegesSetToString(priviligesSet *schema.Set) string {
 	if priviligesSet.Contains("ALL") {
 		return "ALL"


### PR DESCRIPTION
**What**
- Use correct types for values passed to `Set`

**Why**
The package that terraform uses `github.com/mitchellh/mapstructure` to decode values, does not support `sql.NullString`.

All the calls to `d.Set` were returning errors. For whatever reason, ignoring errors is common practice throughout various terraform providers so we're not changing that here.

This change passes the correct primitives and in our cases, none of the values can be null in the database so there is no need for `sql.NullString`.

**Testing**
- Create a warehouse, db, and schema with terraform
- Delete schema manually, ensure terraform recreates it
- Delete db manually, make sure terraform recreates it and schema
- Delete warehouse manually, make sure terraform recreates it
- Change warehouse size, max cluster size, auto suspend period, and comment manually, make sure terraform sees change and can update
